### PR TITLE
Fix an issue when moving the cursor from second line

### DIFF
--- a/CompletionEngineTest/CompletionEngineTest.m
+++ b/CompletionEngineTest/CompletionEngineTest.m
@@ -60,7 +60,7 @@
     [self.codes insertText:@"\n\n"];
     [self MoveCursorByOffset:-1];
     XCTAssert([self.completionEngine OffsetToNextLine:self.codes] == 1);
-    XCTAssert([self.completionEngine OffsetToPrevLine:self.codes] == 0);
+    XCTAssert([self.completionEngine OffsetToPrevLine:self.codes] == -1);
 }
 
 - (void)testMultipleMotionBack {

--- a/FunctionalTests/FunctionalTests.m
+++ b/FunctionalTests/FunctionalTests.m
@@ -147,6 +147,20 @@
     XCTAssert([self getIndex] == 3);
 }
 
+- (void) testSimpleMoveUp {
+    [self pressKey:@"a"];
+    [self pressKey:ENTER];
+    [self pressKey:@"b"];
+    XCTAssert([self getIndex] == 3);
+    
+    [self.app MoveCursorLeft:nil];
+    XCTAssert([self getIndex] == 2);
+
+    [self.app MoveCursorUp:nil];
+    XCTAssert([self getIndex] == 0);
+
+}
+
 - (void)testMovingDown {
     [self pressKey:@"{"];
     [self assertString:@"{\n    \n}"];

--- a/Programming_Keyboard.xcodeproj/xcuserdata/junlong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Programming_Keyboard.xcodeproj/xcuserdata/junlong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -411,6 +411,68 @@
             endingLineNumber = "85"
             landmarkName = "-testMotionForwardOverflow"
             landmarkType = "7">
+            <Locations>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testMotionForwardOverflow]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.042262"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "85"
+                  endingLineNumber = "85"
+                  offsetFromSymbolStart = "116">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testMotionForwardOverflow]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.044234"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "85"
+                  endingLineNumber = "85"
+                  offsetFromSymbolStart = "588">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testMotionForwardOverflow]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.04614"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "85"
+                  endingLineNumber = "85"
+                  offsetFromSymbolStart = "624">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testMotionForwardOverflow]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.048042"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "85"
+                  endingLineNumber = "85"
+                  offsetFromSymbolStart = "704">
+               </Location>
+            </Locations>
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -484,11 +546,11 @@
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "FunctionalTests/FunctionalTests.m"
-            timestampString = "499741173.785159"
+            timestampString = "499972349.896211"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "159"
-            endingLineNumber = "159"
+            startingLineNumber = "173"
+            endingLineNumber = "173"
             landmarkName = "-testMovingDown"
             landmarkType = "7">
          </BreakpointContent>
@@ -523,6 +585,68 @@
             endingLineNumber = "55"
             landmarkName = "-testFindPreviousLineCursor"
             landmarkType = "7">
+            <Locations>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindPreviousLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.051416"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "55"
+                  endingLineNumber = "55"
+                  offsetFromSymbolStart = "96">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindPreviousLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.053352"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "55"
+                  endingLineNumber = "55"
+                  offsetFromSymbolStart = "568">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindPreviousLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.055269"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "55"
+                  endingLineNumber = "55"
+                  offsetFromSymbolStart = "1008">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindPreviousLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.057227"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "55"
+                  endingLineNumber = "55"
+                  offsetFromSymbolStart = "1088">
+               </Location>
+            </Locations>
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy

--- a/Programming_Keyboard.xcworkspace/xcshareddata/xcschemes/Programming_Keyboard.xcscheme
+++ b/Programming_Keyboard.xcworkspace/xcshareddata/xcschemes/Programming_Keyboard.xcscheme
@@ -87,7 +87,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Programming_Keyboard.xcworkspace/xcuserdata/junlong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Programming_Keyboard.xcworkspace/xcuserdata/junlong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -17,38 +17,6 @@
             endingLineNumber = "56"
             landmarkName = "-viewDidLayoutSubviews"
             landmarkType = "7">
-            <Locations>
-               <Location
-                  shouldBeEnabled = "Yes"
-                  ignoreCount = "0"
-                  continueAfterRunningActions = "No"
-                  symbolName = "-[Container viewDidLayoutSubviews]"
-                  moduleName = "Programming_Keyboard"
-                  usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/Container.m"
-                  timestampString = "499740940.370475"
-                  startingColumnNumber = "9223372036854775807"
-                  endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "54"
-                  endingLineNumber = "54"
-                  offsetFromSymbolStart = "412">
-               </Location>
-               <Location
-                  shouldBeEnabled = "Yes"
-                  ignoreCount = "0"
-                  continueAfterRunningActions = "No"
-                  symbolName = "-[Container viewDidLayoutSubviews]"
-                  moduleName = "FunctionalTests"
-                  usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/Container.m"
-                  timestampString = "499740940.936125"
-                  startingColumnNumber = "9223372036854775807"
-                  endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "54"
-                  endingLineNumber = "54"
-                  offsetFromSymbolStart = "412">
-               </Location>
-            </Locations>
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -74,27 +42,27 @@
                   moduleName = "Programming_Keyboard"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.374661"
+                  timestampString = "499973756.623335"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "244"
-                  endingLineNumber = "244"
-                  offsetFromSymbolStart = "64">
+                  startingLineNumber = "255"
+                  endingLineNumber = "255"
+                  offsetFromSymbolStart = "84">
                </Location>
                <Location
                   shouldBeEnabled = "Yes"
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
                   symbolName = "-[Container(KeyboardCatagory) popoverPresentationControllerDidDismissPopover:]"
-                  moduleName = "FunctionalTests"
+                  moduleName = "CompletionEngineTest"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.939178"
+                  timestampString = "499973757.027328"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "244"
-                  endingLineNumber = "244"
-                  offsetFromSymbolStart = "64">
+                  startingLineNumber = "255"
+                  endingLineNumber = "255"
+                  offsetFromSymbolStart = "84">
                </Location>
             </Locations>
          </BreakpointContent>
@@ -122,11 +90,11 @@
                   moduleName = "Programming_Keyboard"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.38784"
+                  timestampString = "499973756.626335"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "103"
-                  endingLineNumber = "103"
+                  startingLineNumber = "105"
+                  endingLineNumber = "105"
                   offsetFromSymbolStart = "72">
                </Location>
                <Location
@@ -134,14 +102,14 @@
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
                   symbolName = "-[Container(KeyboardCatagory) BackSpaceButton:]"
-                  moduleName = "FunctionalTests"
+                  moduleName = "CompletionEngineTest"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.967364"
+                  timestampString = "499973757.030662"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "103"
-                  endingLineNumber = "103"
+                  startingLineNumber = "105"
+                  endingLineNumber = "105"
                   offsetFromSymbolStart = "72">
                </Location>
             </Locations>
@@ -170,11 +138,11 @@
                   moduleName = "Programming_Keyboard"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.391122"
+                  timestampString = "499973756.629492"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "274"
-                  endingLineNumber = "274"
+                  startingLineNumber = "292"
+                  endingLineNumber = "292"
                   offsetFromSymbolStart = "72">
                </Location>
                <Location
@@ -182,14 +150,14 @@
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
                   symbolName = "-[Container(KeyboardCatagory) TouchEnd:]"
-                  moduleName = "FunctionalTests"
+                  moduleName = "CompletionEngineTest"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.970142"
+                  timestampString = "499973757.033806"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "274"
-                  endingLineNumber = "274"
+                  startingLineNumber = "292"
+                  endingLineNumber = "292"
                   offsetFromSymbolStart = "72">
                </Location>
             </Locations>
@@ -218,11 +186,11 @@
                   moduleName = "Programming_Keyboard"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.394163"
+                  timestampString = "499973756.63247"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "265"
-                  endingLineNumber = "265"
+                  startingLineNumber = "281"
+                  endingLineNumber = "281"
                   offsetFromSymbolStart = "72">
                </Location>
                <Location
@@ -230,14 +198,14 @@
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
                   symbolName = "-[Container(KeyboardCatagory) TouchBegin:]"
-                  moduleName = "FunctionalTests"
+                  moduleName = "CompletionEngineTest"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.972849"
+                  timestampString = "499973757.036773"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "265"
-                  endingLineNumber = "265"
+                  startingLineNumber = "281"
+                  endingLineNumber = "281"
                   offsetFromSymbolStart = "72">
                </Location>
             </Locations>
@@ -266,11 +234,11 @@
                   moduleName = "Programming_Keyboard"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.397154"
+                  timestampString = "499973756.643023"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "169"
-                  endingLineNumber = "169"
+                  startingLineNumber = "173"
+                  endingLineNumber = "173"
                   offsetFromSymbolStart = "68">
                </Location>
                <Location
@@ -278,15 +246,127 @@
                   ignoreCount = "0"
                   continueAfterRunningActions = "No"
                   symbolName = "-[Container(KeyboardCatagory) CompletionLanguageSelected:]"
-                  moduleName = "FunctionalTests"
+                  moduleName = "CompletionEngineTest"
                   usesParentBreakpointCondition = "Yes"
                   urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/KeyboardCatagory.m"
-                  timestampString = "499740940.975505"
+                  timestampString = "499973757.039453"
                   startingColumnNumber = "9223372036854775807"
                   endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "169"
-                  endingLineNumber = "169"
+                  startingLineNumber = "173"
+                  endingLineNumber = "173"
                   offsetFromSymbolStart = "68">
+               </Location>
+            </Locations>
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "FunctionalTests/FunctionalTests.m"
+            timestampString = "499972336.547446"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "150"
+            endingLineNumber = "150"
+            landmarkName = "-testSimpleMoveUp"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "FunctionalTests/FunctionalTests.m"
+            timestampString = "499972369.842702"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "160"
+            endingLineNumber = "160"
+            landmarkName = "-testSimpleMoveUp"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "FunctionalTests/FunctionalTests.m"
+            timestampString = "499972394.328877"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "159"
+            endingLineNumber = "159"
+            landmarkName = "-testSimpleMoveUp"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "FunctionalTests/FunctionalTests.m"
+            timestampString = "499972602.038721"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "172"
+            endingLineNumber = "172"
+            landmarkName = "-testMovingDown"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Programming_Keyboard/CompletionEngine.m"
+            timestampString = "499973380.352733"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "347"
+            endingLineNumber = "347"
+            landmarkName = "-OffsetToLineOffset:code:"
+            landmarkType = "7">
+            <Locations>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngine OffsetToLineOffset:code:]"
+                  moduleName = "Programming_Keyboard"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/CompletionEngine.m"
+                  timestampString = "499973756.658269"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "347"
+                  endingLineNumber = "347"
+                  offsetFromSymbolStart = "264">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngine OffsetToLineOffset:code:]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/Programming_Keyboard/CompletionEngine.m"
+                  timestampString = "499973757.060525"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "347"
+                  endingLineNumber = "347"
+                  offsetFromSymbolStart = "264">
                </Location>
             </Locations>
          </BreakpointContent>
@@ -297,14 +377,154 @@
             shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "FunctionalTests/FunctionalTests.m"
-            timestampString = "499741173.785159"
+            filePath = "CompletionEngineTest/CompletionEngineTest.m"
+            timestampString = "499973568.130008"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "60"
-            endingLineNumber = "60"
-            landmarkName = "-pressKey:"
+            startingLineNumber = "63"
+            endingLineNumber = "63"
+            landmarkName = "-testFindNextLineCursor"
             landmarkType = "7">
+            <Locations>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.063379"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "63"
+                  endingLineNumber = "63"
+                  offsetFromSymbolStart = "592">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.065527"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "63"
+                  endingLineNumber = "63"
+                  offsetFromSymbolStart = "1760">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.06768"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "63"
+                  endingLineNumber = "63"
+                  offsetFromSymbolStart = "1796">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.069781"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "63"
+                  endingLineNumber = "63"
+                  offsetFromSymbolStart = "1876">
+               </Location>
+            </Locations>
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "CompletionEngineTest/CompletionEngineTest.m"
+            timestampString = "499973569.507984"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "62"
+            endingLineNumber = "62"
+            landmarkName = "-testFindNextLineCursor"
+            landmarkType = "7">
+            <Locations>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.072937"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "62"
+                  endingLineNumber = "62"
+                  offsetFromSymbolStart = "116">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.074927"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "62"
+                  endingLineNumber = "62"
+                  offsetFromSymbolStart = "588">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.076844"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "62"
+                  endingLineNumber = "62"
+                  offsetFromSymbolStart = "1028">
+               </Location>
+               <Location
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "-[CompletionEngineTest testFindNextLineCursor]"
+                  moduleName = "CompletionEngineTest"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/junlong/workspace/Programming_Keyboard/CompletionEngineTest/CompletionEngineTest.m"
+                  timestampString = "499973757.078755"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "62"
+                  endingLineNumber = "62"
+                  offsetFromSymbolStart = "1108">
+               </Location>
+            </Locations>
          </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>

--- a/Programming_Keyboard/Base.lproj/Main.storyboard
+++ b/Programming_Keyboard/Base.lproj/Main.storyboard
@@ -637,7 +637,7 @@
         <scene sceneID="CNa-01-lak">
             <objects>
                 <tableViewController storyboardIdentifier="CompletionSelection" useStoryboardIdentifierAsRestorationIdentifier="YES" id="mqE-tb-JQq" customClass="CompletionLanguageSelectionController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="dal-vV-G82">
+                    <tableView key="view" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="dal-vV-G82">
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -674,7 +674,7 @@
         <scene sceneID="zdS-v7-OL4">
             <objects>
                 <tableViewController storyboardIdentifier="autoCompletionPanel" useStoryboardIdentifierAsRestorationIdentifier="YES" id="KIE-z8-aTv" customClass="AutoCompletionPanelController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="1Cq-3P-RAO">
+                    <tableView key="view" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="1Cq-3P-RAO">
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Programming_Keyboard/CompletionEngine.m
+++ b/Programming_Keyboard/CompletionEngine.m
@@ -368,7 +368,13 @@
                 offset++;
             }
             if(offset == 0 || i == 0){
-                target = i+1; break;
+                target = i+1;
+                if(i == 0 && offset < 0){
+                        //i should bounce back to the start of the document
+                        //instead of pointing to previous line end
+                    target = i;
+                }
+                break;
             }
         }
     }


### PR DESCRIPTION
to the first line. This issue occurs internally is that
when moving line offset, the destination tries to point
to a non existing position: index -1 representing the
new line character before the whole document. This will
happen when the offset needed is at least one more
than the line left to the beginning.

The issue is resolved by checking offset explicitly
when index is at 0.